### PR TITLE
fix: display wall textures opposite direction textures

### DIFF
--- a/bonus/src/game/raycasting_bonus.c
+++ b/bonus/src/game/raycasting_bonus.c
@@ -6,7 +6,7 @@
 /*   By: totake <totake@student.42tokyo.jp>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2026/04/22 13:13:42 by totake            #+#    #+#             */
-/*   Updated: 2026/04/22 13:13:48 by totake           ###   ########.fr       */
+/*   Updated: 2026/04/29 16:08:17 by totake           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -71,11 +71,11 @@ static t_ray_result	cast_single_ray(t_cub3d *app, double ray_x, double ray_y)
  *
  * ray->step_x / ray->step_y:
  *   indicate the ray movement direction:
- *     negative → ray moving toward WEST or NORTH
- *     positive → ray moving toward EAST or SOUTH
+ *     negative → ray moving toward WEST or NORTH → display EAST or SOUTH texture
+ *     positive → ray moving toward EAST or SOUTH → display WEST or NORTH texture
  *
  * Returns:
- *   Texture index corresponding to wall orientation.
+ *   Texture index corresponding to opposite wall orientation.
  */
 
 static int	select_texture(t_ray_result *ray)
@@ -83,12 +83,12 @@ static int	select_texture(t_ray_result *ray)
 	if (ray->side == 0)
 	{
 		if (ray->step_x < 0)
-			return (TEX_WEST);
-		return (TEX_EAST);
+			return (TEX_EAST);
+		return (TEX_WEST);
 	}
 	if (ray->step_y < 0)
-		return (TEX_NORTH);
-	return (TEX_SOUTH);
+		return (TEX_SOUTH);
+	return (TEX_NORTH);
 }
 
 /*

--- a/mandatory/src/game/raycasting.c
+++ b/mandatory/src/game/raycasting.c
@@ -6,7 +6,7 @@
 /*   By: totake <totake@student.42tokyo.jp>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2026/02/20 16:00:00 by totake            #+#    #+#             */
-/*   Updated: 2026/04/17 16:38:34 by totake           ###   ########.fr       */
+/*   Updated: 2026/04/29 16:07:55 by totake           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -71,11 +71,11 @@ static t_ray_result	cast_single_ray(t_cub3d *app, double ray_x, double ray_y)
  *
  * ray->step_x / ray->step_y:
  *   indicate the ray movement direction:
- *     negative → ray moving toward WEST or NORTH
- *     positive → ray moving toward EAST or SOUTH
+ *     negative → ray moving toward WEST or NORTH → display EAST or SOUTH texture
+ *     positive → ray moving toward EAST or SOUTH → display WEST or NORTH texture
  *
  * Returns:
- *   Texture index corresponding to wall orientation.
+ *   Texture index corresponding to opposite wall orientation.
  */
 
 static int	select_texture(t_ray_result *ray)
@@ -83,12 +83,12 @@ static int	select_texture(t_ray_result *ray)
 	if (ray->side == 0)
 	{
 		if (ray->step_x < 0)
-			return (TEX_WEST);
-		return (TEX_EAST);
+			return (TEX_EAST);
+		return (TEX_WEST);
 	}
 	if (ray->step_y < 0)
-		return (TEX_NORTH);
-	return (TEX_SOUTH);
+		return (TEX_SOUTH);
+	return (TEX_NORTH);
 }
 
 /*


### PR DESCRIPTION
## 概要
<!-- PRの背景・目的・概要 -->


## 関連タスク
<!-- 関連するIssueやチケットのリンクを貼る。Issueの場合は、「#<IssueNumber>」でリンクできる -->


## やったこと
<!-- このPRで何をしたのか？ -->
textureの表示を壁をボックスと捉えて北面には北テクスチャ、南面には南テクスチャを表示するように変更した


## やらないこと
<!-- このPRでやらないことは何か？ -->


## 影響範囲
<!-- 影響を及ぼす範囲や他の機能への影響 -->


## テスト
<!-- テスト方法や結果 -->
実際にプレイヤーの向きを東西南北で変更して適切に表示されるか検証した。

## 備考
<!-- レビュワーへの伝達事項や残しておきたい情報 -->
セレクトテキスチャを変更下だけです。軽く確認お願いします。